### PR TITLE
Fix master branch build

### DIFF
--- a/checkstyle-all/pom.xml
+++ b/checkstyle-all/pom.xml
@@ -46,6 +46,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
               <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
               <artifactSet>
                 <includes>

--- a/sonar-checkstyle-plugin/pom.xml
+++ b/sonar-checkstyle-plugin/pom.xml
@@ -83,6 +83,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>checkstyle-all</artifactId>
       <version>${project.version}</version>
+      <classifier>shaded</classifier>
     </dependency>
 
     <!-- TODO http://jira.codehaus.org/browse/SONAR-2011

--- a/sonar-checkstyle-plugin/src/main/resources/com/sonar/sqale/checkstyle-model.xml
+++ b/sonar-checkstyle-plugin/src/main/resources/com/sonar/sqale/checkstyle-model.xml
@@ -437,6 +437,19 @@
       </chc>
       <chc>
         <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.naming.CatchParameterNameCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>10</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
         <rule-key>com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck</rule-key>
         <prop>
           <key>remediationFunction</key>
@@ -529,6 +542,19 @@
       <chc>
         <rule-repo>checkstyle</rule-repo>
         <rule-key>com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>1</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</rule-key>
         <prop>
           <key>remediationFunction</key>
           <txt>CONSTANT_ISSUE</txt>

--- a/sonar-checkstyle-plugin/src/main/resources/org/sonar/l10n/checkstyle.properties
+++ b/sonar-checkstyle-plugin/src/main/resources/org/sonar/l10n/checkstyle.properties
@@ -38,6 +38,8 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck.name=Typecast Paren Pad
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck.param.option=policy on how to pad parentheses
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck.param.tokens=tokens to check
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck.name=Single Space Separator
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck.param.validateComments=If set to true, whitespaces surrounding comments will be ignored. Default is false
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck.name=Avoid Static Import
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck.param.excludes=Allows for certain classes via a star notation to be excluded such as java.lang.Math.* or specific static members to be excluded like java.lang.System.out for a variable or java.lang.Math.random for a method. If you exclude a starred import on a class this automatically excludes each member individually. For example: Excluding java.lang.Math.*. will allow the import of each static member in the Math class individually like java.lang.Math.PI.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck.name=Return Count
@@ -324,7 +326,9 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifier
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.param.publicMemberPattern=pattern for public members that should be ignored.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.param.packageAllowed=whether package visible members are allowed.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.param.allowPublicImmutableFields=allows immutable fields to be declared as public.
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.param.allowPublicFinalFields=allows public final fields. Default is false
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.param.ignoreAnnotationCanonicalNames=ignore annotations canonical names
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck.param.immutableClassCanonicalNames=immutable classes canonical names
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck.name=String Literal Equality
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck.name=Class Data Abstraction Coupling
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.metrics.ClassDataAbstractionCouplingCheck.param.max=the maximum threshold allowed. Default is 7.
@@ -352,6 +356,7 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceArou
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.param.allowEmptyMethods=allow empty method bodies. Default is false.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.param.allowEmptyTypes=allow empty class, interface and enum bodies
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.param.allowEmptyLoops=allow empty loop bodies
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.param.allowEmptyLambdas=allow empty lambda bodies. Default is false.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck.param.ignoreEnhancedForColon=ignore whitespace around colon in for-each loops
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck.name=No Finalizer
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.UpperEllCheck.name=Upper Ell

--- a/sonar-checkstyle-plugin/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/sonar-checkstyle-plugin/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -30,14 +30,16 @@ import static org.fest.assertions.Assertions.assertThat;
 public class CheckstyleRulesDefinitionTest {
 
   List<String> NO_SQALE = ImmutableList.of(
+    "com.puppycrawl.tools.checkstyle.checks.TranslationCheck",
     "com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck",
     "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck",
+    "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck",
     "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck",
-    "com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck",
+    "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck",
     "com.puppycrawl.tools.checkstyle.checks.RegexpCheck",
+    "com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck",
     "com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck",
-    "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck",
-    "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck"
+    "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"
   );
 
   @Test
@@ -51,7 +53,7 @@ public class CheckstyleRulesDefinitionTest {
     assertThat(repository.language()).isEqualTo("java");
 
     List<RulesDefinition.Rule> rules = repository.rules();
-    assertThat(rules).hasSize(146);
+    assertThat(rules).hasSize(150);
 
     for (RulesDefinition.Rule rule : rules) {
       assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
This commit contains a couple of changes that fix the master branch
build:

 - Add Sqale configurations for new rules where it makes sense. I'm not
   familiar with Sqale and had to guess.
 - Set a classifier for the shaded artifact and use that. This makes
   sure the relocated Guava version is used for Checkstyle and the
   not-relocated one for Sonar.
 - Incremented the expected rule count.
 - Add more mission translations.

I did not yet test a SNAPSHOT build against Sonar.