### PR TITLE
Lessen dependency on Guava

### DIFF
--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleConfiguration.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleConfiguration.java
@@ -26,6 +26,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -39,7 +40,6 @@ import org.sonar.api.config.Settings;
 import org.sonar.api.profiles.RulesProfile;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
@@ -86,7 +86,11 @@ public class CheckstyleConfiguration implements BatchExtension {
     Iterable<File> files = fileSystem.files(predicates.and(
       predicates.hasLanguage(CheckstyleConstants.JAVA_KEY),
       predicates.hasType(InputFile.Type.MAIN)));
-    return ImmutableList.<File>builder().addAll(files).build();
+    List<File> fileList = new ArrayList<>();
+    for (File file : files) {
+      fileList.add(file);
+    }
+    return fileList;
   }
 
   public File getTargetXmlReport() {

--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstylePlugin.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstylePlugin.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.checkstyle;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.sonar.api.CoreProperties;
@@ -27,15 +28,13 @@ import org.sonar.api.SonarPlugin;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 
-import com.google.common.collect.ImmutableList;
-
 public final class CheckstylePlugin extends SonarPlugin {
 
   private static final String CHECKSTYLE_SUB_CATEGORY_NAME = "Checkstyle";
 
   @Override
   public List getExtensions() {
-    return ImmutableList.of(
+    return Arrays.asList(
       PropertyDefinition
         .builder(CheckstyleConstants.FILTERS_KEY)
         .defaultValue(CheckstyleConstants.FILTERS_DEFAULT_VALUE)

--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporter.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporter.java
@@ -20,6 +20,8 @@
 package org.sonar.plugins.checkstyle;
 
 import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,8 +42,6 @@ import org.sonar.api.rules.RuleQuery;
 import org.sonar.api.utils.ValidationMessages;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 public class CheckstyleProfileImporter extends ProfileImporter {
 
@@ -61,8 +61,8 @@ public class CheckstyleProfileImporter extends ProfileImporter {
 
   private static class Module {
     private String name;
-    private final Map<String, String> properties = Maps.newHashMap();
-    private final List<Module> modules = Lists.newArrayList();
+    private final Map<String, String> properties = new HashMap<>();
+    private final List<Module> modules = new ArrayList<>();
   }
 
   public CheckstyleProfileImporter(RuleFinder ruleFinder) {
@@ -96,7 +96,7 @@ public class CheckstyleProfileImporter extends ProfileImporter {
       Module checkerModule = loadModule(inputFactory.rootElementCursor(reader).advance());
 
       for (Module rootModule : checkerModule.modules) {
-        Map<String, String> rootModuleProperties = Maps.newHashMap(checkerModule.properties);
+        Map<String, String> rootModuleProperties = new HashMap<>(checkerModule.properties);
         rootModuleProperties.putAll(rootModule.properties);
 
         if (StringUtils.equals(TREEWALKER_MODULE, rootModule.name)) {
@@ -119,7 +119,7 @@ public class CheckstyleProfileImporter extends ProfileImporter {
                                  Map<String, String> rootModuleProperties,
                                  ValidationMessages messages) {
     for (Module treewalkerModule : rootModule.modules) {
-      Map<String, String> treewalkerModuleProperties = Maps.newHashMap(rootModuleProperties);
+      Map<String, String> treewalkerModuleProperties = new HashMap<>(rootModuleProperties);
       treewalkerModuleProperties.putAll(treewalkerModule.properties);
 
       processModule(profile, CHECKER_MODULE + "/" + TREEWALKER_MODULE + "/",

--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
@@ -29,8 +29,6 @@ import org.sonar.api.batch.fs.InputFile.Type;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.resources.Project;
 
-import com.google.common.collect.Iterables;
-
 public class CheckstyleSensor implements Sensor {
 
   private final RulesProfile profile;
@@ -49,7 +47,8 @@ public class CheckstyleSensor implements Sensor {
     Iterable<File> mainFiles = fs.files(predicates.and(
       predicates.hasLanguage(CheckstyleConstants.JAVA_KEY),
       predicates.hasType(Type.MAIN)));
-    return !Iterables.isEmpty(mainFiles) &&
+    boolean mainFilesIsEmpty = !mainFiles.iterator().hasNext();
+    return !mainFilesIsEmpty &&
         !profile.getActiveRulesByRepository(CheckstyleConstants.REPOSITORY_KEY).isEmpty();
   }
 

--- a/checkstyle-sonar-plugin/src/test/java/org/sonar/plugins/checkstyle/internal/ChecksTest.java
+++ b/checkstyle-sonar-plugin/src/test/java/org/sonar/plugins/checkstyle/internal/ChecksTest.java
@@ -26,10 +26,12 @@ import java.beans.PropertyDescriptor;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -183,13 +185,15 @@ public final class ChecksTest {
         Assert.assertTrue("'checkstyle.properties' must exist", propertiesFile.exists());
 
         final Properties properties = new Properties();
-        properties.load(new FileInputStream(propertiesFile));
+        try (InputStream stream = new FileInputStream(propertiesFile)) {
+          properties.load(stream);
+        }
 
         validateSonarProperties(properties, modules);
     }
 
-    private static void validateSonarProperties(Properties properties, Set<Class<?>> modules)
-            {
+    private static void validateSonarProperties(Map<Object, Object> properties,
+            Set<Class<?>> modules) {
         Class<?> lastModule = null;
         Set<String> moduleProperties = null;
 


### PR DESCRIPTION
The plugin currently depends on Guava. For checkstyle itself this is
not an issue but for the plugin it has negative consequences. Before
SonarQube 5.2 this meant that the version of Guava the plugin uses and
the one that SonarQube uses had to match. This can be a challenge
because the Google versioning policy is rather opionated. In SonarQube
5.2 and later sonar-packaging-maven-plugin stubbornly refuses to
package Guava because it is not aware of the class loading changes in
5.2 and assumes Guava is still provided by SonarQube when in fact it's
not.

With these changes the only Guava dependencies left in the source of
the plugin are VisibleForTesting. As this is only an annotation for
documentation purposes it is inconsequential if it can't be loaded at
runtime.

The tests still depend on Guava but this is fine.

 [1] https://docs.sonarqube.org/display/DEV/Build