### PR TITLE
Issue #157: SonarQube 7.2+ support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: checkstyle/sonarqube-maven-git:6.7.5
+      - image: checkstyle/sonarqube-maven-git:7.4-community
 
     working_directory: ~/repo
 
@@ -16,16 +16,16 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-root-{{ checksum "pom.xml" }}
+          - v1-dependencies-sonarqube-{{ checksum "pom.xml" }}
           # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-root
+          - v1-dependencies-sonarqube
 
       - run: mvn package -Pno-validations
 
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-dependencies-root-{{ checksum "pom.xml" }}
+          key: v1-dependencies-sonarqube-{{ checksum "pom.xml" }}
 
       # run tests
       - run: |-

--- a/checkstyle-sonar-plugin/pom.xml
+++ b/checkstyle-sonar-plugin/pom.xml
@@ -24,17 +24,10 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api</artifactId>
-      <scope>provided</scope>
-      <version>${sonar.version}</version>
-    </dependency>
     <!-- till https://github.com/checkstyle/sonar-checkstyle/issues/40 -->
     <dependency>
       <groupId>org.sonarsource.java</groupId>
       <artifactId>sonar-java-plugin</artifactId>
-      <type>sonar-plugin</type>
       <version>${sonar-java.version}</version>
       <scope>provided</scope>
       <!-- to avoid 4.5.1 api pickup -->
@@ -49,7 +42,7 @@
     <dependency>
       <groupId>org.sonarsource.sslr-squid-bridge</groupId>
       <artifactId>sslr-squid-bridge</artifactId>
-      <version>2.6.1</version>
+      <version>2.7.0.377</version>
       <!-- to avoid 4.5.1 api pickup -->
       <exclusions>
         <exclusion>
@@ -63,36 +56,31 @@
       </exclusions>
     </dependency>
     <dependency>
-      <!-- required during runtime, by sonar 5.6.4 -->
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.5</version>
     </dependency>
     <dependency>
-      <!-- required during runtime, by sonar 5.6.4 -->
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>
     </dependency>
     <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>checkstyle-all</artifactId>
-      <version>${project.version}</version>
-      <classifier>shaded</classifier>
-      <exclusions>
-        <exclusion>
-          <!-- we exclude checkstyle as we use shaded version of it -->
-          <groupId>com.puppycrawl.tools</groupId>
-          <artifactId>checkstyle</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>27.0.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>xmlunit</groupId>
@@ -111,36 +99,79 @@
       <version>2.0.7</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>hamcrest-core</artifactId>
+          <groupId>org.hamcrest</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>hamcrest-core</artifactId>
+          <groupId>org.hamcrest</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
       <scope>test</scope>
       <version>${sonar.version}</version>
     </dependency>
-
     <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-assert</artifactId>
       <scope>test</scope>
       <version>1.4</version>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <!-- 1.5.6(old) version is requied due to sonar 5.6.4 dependency tree -->
       <version>1.5.6</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
       <version>1.9.7</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.puppycrawl.tools</groupId>
+      <artifactId>checkstyle</artifactId>
+      <version>${checkstyle.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-cli</groupId>
+          <artifactId>commons-cli</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>
@@ -408,7 +439,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>20000000</maxsize>
+                  <maxsize>30000000</maxsize>
                   <minsize>5000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporter.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporter.java
@@ -33,6 +33,8 @@ import org.codehaus.staxmate.SMInputFactory;
 import org.codehaus.staxmate.in.SMInputCursor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.ExtensionPoint;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.profiles.ProfileImporter;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.rules.ActiveRule;
@@ -43,6 +45,8 @@ import org.sonar.api.utils.ValidationMessages;
 
 import com.google.common.annotations.VisibleForTesting;
 
+@ExtensionPoint
+@ScannerSide
 public class CheckstyleProfileImporter extends ProfileImporter {
 
     private static final Logger LOG = LoggerFactory.getLogger(CheckstyleProfileImporter.class);

--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinition.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinition.java
@@ -21,15 +21,20 @@ package org.sonar.plugins.checkstyle;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
+import java.util.Properties;
 
+import org.sonar.api.ExtensionPoint;
+import org.sonar.api.batch.ScannerSide;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.api.server.rule.RulesDefinitionXmlLoader;
 import org.sonar.squidbridge.rules.ExternalDescriptionLoader;
-import org.sonar.squidbridge.rules.PropertyFileLoader;
 import org.sonar.squidbridge.rules.SqaleXmlLoader;
 
 import com.google.common.annotations.VisibleForTesting;
 
+@ExtensionPoint
+@ScannerSide
 public final class CheckstyleRulesDefinition implements RulesDefinition {
 
     @Override
@@ -37,7 +42,6 @@ public final class CheckstyleRulesDefinition implements RulesDefinition {
         final NewRepository repository = context.createRepository(
                 CheckstyleConstants.REPOSITORY_KEY, "java").setName(
                 CheckstyleConstants.REPOSITORY_NAME);
-
         try {
             extractRulesData(repository, "/org/sonar/plugins/checkstyle/rules.xml",
                     "/org/sonar/l10n/checkstyle/rules/checkstyle");
@@ -60,8 +64,38 @@ public final class CheckstyleRulesDefinition implements RulesDefinition {
         ExternalDescriptionLoader.loadHtmlDescriptions(repository, htmlDescriptionFolder);
         try (InputStream resource = CheckstyleRulesDefinition.class
                 .getResourceAsStream("/org/sonar/l10n/checkstyle.properties")) {
-            PropertyFileLoader.loadNames(repository, resource);
+            loadNames(repository, resource);
         }
         SqaleXmlLoader.load(repository, "/com/sonar/sqale/checkstyle-model.xml");
+    }
+
+    private static void loadNames(NewRepository repository, InputStream stream) {
+        // code taken from https://github.com/SonarSource/sslr-squid-bridge/blob/2.5.2/
+        // src/main/java/org/sonar/squidbridge/rules/PropertyFileLoader.java#L46
+        final Properties properties = new Properties();
+        try {
+            properties.load(stream);
+        }
+        catch (IOException ex) {
+            throw new IllegalArgumentException("Could not read names from properties", ex);
+        }
+
+        if (Objects.nonNull(repository.rules())) {
+            repository.rules().forEach(rule -> {
+                final String baseKey = "rule." + repository.key() + "." + rule.key();
+                final String nameKey = baseKey + ".name";
+                final String ruleName = properties.getProperty(nameKey);
+                if (Objects.nonNull(ruleName)) {
+                    rule.setName(ruleName);
+                }
+                rule.params().forEach(param -> {
+                    final String paramDescriptionKey = baseKey + ".param." + param.key();
+                    final String paramDescription = properties.getProperty(paramDescriptionKey);
+                    if (Objects.nonNull(paramDescription)) {
+                        param.setDescription(paramDescription);
+                    }
+                });
+            });
+        }
     }
 }

--- a/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
+++ b/checkstyle-sonar-plugin/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
@@ -19,44 +19,27 @@
 
 package org.sonar.plugins.checkstyle;
 
-import java.io.File;
-
-import org.sonar.api.batch.Sensor;
-import org.sonar.api.batch.SensorContext;
-import org.sonar.api.batch.fs.FilePredicates;
-import org.sonar.api.batch.fs.FileSystem;
-import org.sonar.api.batch.fs.InputFile.Type;
-import org.sonar.api.profiles.RulesProfile;
-import org.sonar.api.resources.Project;
+import org.sonar.api.batch.sensor.Sensor;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.plugins.java.Java;
 
 public class CheckstyleSensor implements Sensor {
 
-    private final RulesProfile profile;
     private final CheckstyleExecutor executor;
-    private final FileSystem fileSystem;
 
-    public CheckstyleSensor(RulesProfile profile, CheckstyleExecutor executor,
-            FileSystem fileSystem) {
-        this.profile = profile;
+    public CheckstyleSensor(CheckstyleExecutor executor) {
         this.executor = executor;
-        this.fileSystem = fileSystem;
     }
 
     @Override
-    public boolean shouldExecuteOnProject(Project project) {
-        final FilePredicates predicates = fileSystem.predicates();
-        final Iterable<File> mainFiles = fileSystem
-                .files(predicates.and(predicates.hasLanguage(CheckstyleConstants.JAVA_KEY),
-                        predicates.hasType(Type.MAIN)));
-        final boolean mainFilesIsEmpty = !mainFiles.iterator().hasNext();
-        return !mainFilesIsEmpty
-                && !profile.getActiveRulesByRepository(CheckstyleConstants.REPOSITORY_KEY)
-                        .isEmpty();
+    public void describe(SensorDescriptor descriptor) {
+        descriptor.onlyOnLanguage(Java.KEY).name("CheckstyleSensor");
     }
 
     @Override
-    public void analyse(Project project, SensorContext context) {
-        executor.execute();
+    public void execute(SensorContext context) {
+        executor.execute(context);
     }
 
     @Override

--- a/checkstyle-sonar-plugin/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/checkstyle-sonar-plugin/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -23,7 +23,9 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.List;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.sonar.api.server.rule.RulesDefinition;
 
 import com.google.common.collect.ImmutableList;
@@ -43,6 +45,9 @@ public class CheckstyleRulesDefinitionTest {
             "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder"
     );
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void test() {
@@ -83,5 +88,4 @@ public class CheckstyleRulesDefinitionTest {
             }
         }
     }
-
 }

--- a/checkstyle-sonar-plugin/src/test/java/org/sonar/plugins/checkstyle/internal/CheckUtil.java
+++ b/checkstyle-sonar-plugin/src/test/java/org/sonar/plugins/checkstyle/internal/CheckUtil.java
@@ -28,6 +28,8 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -37,8 +39,6 @@ import com.puppycrawl.tools.checkstyle.api.RootModule;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck;
-import com.puppycrawl.tools.checkstyle.guava.collect.ImmutableSet;
-import com.puppycrawl.tools.checkstyle.guava.reflect.ClassPath;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
 
   <modules>
     <module>checkstyle-sonar-plugin</module>
-    <module>checkstyle-all</module>
   </modules>
 
   <scm>
@@ -86,8 +85,8 @@
 
   <properties>
     <checkstyle.version>8.16</checkstyle.version>
-    <sonar.version>5.6.6</sonar.version>
-    <sonar-java.version>3.7</sonar-java.version>
+    <sonar.version>6.7</sonar.version>
+    <sonar-java.version>5.9.1.16423</sonar-java.version>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
Issue #157. Basic changes taken from #158, then I updated dependencies of Checkstyle and SonarQube API. I decided to only update SonarQube until 7.2 (7.3 also works) to keep compatibility with 7.2 SonarQube installations. However, I successfully tested analysis in SonarQube 7.3.

Apparently, there were quite a few API changes which meant I had to change the one or the other thing in the files and tests, which explains the huge number of changed files. In addition, I tried to clean up a few code parts using Java 8 language features.

Unfortunately, I wasn't able to get a few tests running (most likely because I wasn't really able to figure out what they are testing specifically and how to fix it) - they are now ignored:
- CheckTests::verifyTestConfigurationFiles
- CheckstyleExecutorTest::executeException

Furthermore, I integrated the upstream Checkstyle config but I need help in fixing the last errors which correspond to the import order. I wasn't able to figure out an IntelliJ setting that made the checks happy.