### PR TITLE
update sonarqube docker image

### DIFF
--- a/checkstyle-sonar-plugin/config/Dockerfile
+++ b/checkstyle-sonar-plugin/config/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarqube:6.2
+FROM sonarqube:7.4-community
 
 ARG MAVEN_VERSION=3.3.9
 ARG USER_HOME_DIR="/root"


### PR DESCRIPTION
Docker image update to 7.3 but based on alpine.
The reason is that SonarQube officially stopped distributing Docker images due to the different versions. Then, the latest official repository version of the alpine version has been forked and continued with the latest SonarQube versions starting with 7.3.