### PR TITLE
minor: make wercker use strict version of docker image to make CI stable

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: checkstyle/sonarqube-maven-git
+box: checkstyle/sonarqube-maven-git:6.2
 
 build:
   steps:


### PR DESCRIPTION
build problem found at https://app.wercker.com/checkstyle/sonar-checkstyle/runs/build/5c2286e9c0c3d700119431f0?step=5c2286e9c0c3d700119431f5

caused by my latest changes in docker repo to assist #157 

https://hub.docker.com/r/checkstyle/sonarqube-maven-git/tags