### PR TITLE
minor: add javadoc to package-info

### DIFF
--- a/src/main/java/org/sonar/plugins/checkstyle/package-info.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/package-info.java
@@ -16,6 +16,9 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ////////////////////////////////////////////////////////////////////////////////
+/**
+ * Provides the classes for plugin.
+ */
 @ParametersAreNonnullByDefault
 
 package org.sonar.plugins.checkstyle;


### PR DESCRIPTION
add javadoc to package-info
from https://github.com/checkstyle/checkstyle/pull/6798#pullrequestreview-249707120