### PR TITLE
Issue #234: replace sevntu-checkstyle-maven-plugin with sevntu-checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <sonar.version>6.7</sonar.version>
     <sonar-java.version>5.12.0.17701</sonar-java.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
-    <maven.sevntu.checkstyle.plugin.version>1.33.0</maven.sevntu.checkstyle.plugin.version>
+    <maven.sevntu.checkstyle.plugin.version>1.35.0</maven.sevntu.checkstyle.plugin.version>
     <!-- it should be a version of checkstyle that is compatible/compiled with sevntu -->
     <maven.sevntu.checkstyle.plugin.checkstyle.version>
       8.18

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
           </dependency>
           <dependency>
             <groupId>com.github.sevntu-checkstyle</groupId>
-            <artifactId>sevntu-checkstyle-maven-plugin</artifactId>
+            <artifactId>sevntu-checks</artifactId>
             <version>${maven.sevntu.checkstyle.plugin.version}</version>
           </dependency>
         </dependencies>


### PR DESCRIPTION
Issue #234 

- `sevntu-checkstyle-maven-plugin` was replaced with `sevntu-checks dependency`
- `sevntu-checks` bumped to 1.35.0

The two commits are not related to each other, so I split them.