### PR TITLE
Issue #240: update to CS 8.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>8.23</checkstyle.version>
+    <checkstyle.version>8.24</checkstyle.version>
     <sonar.version>6.7</sonar.version>
     <sonar-java.version>5.12.0.17701</sonar-java.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>

--- a/src/main/resources/com/sonar/sqale/checkstyle-model.xml
+++ b/src/main/resources/com/sonar/sqale/checkstyle-model.xml
@@ -1091,6 +1091,19 @@
       </chc>
       <chc>
         <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>30</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
         <rule-key>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</rule-key>
         <prop>
           <key>remediationFunction</key>
@@ -1326,6 +1339,19 @@
       <chc>
         <rule-repo>checkstyle</rule-repo>
         <rule-key>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>10</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck</rule-key>
         <prop>
           <key>remediationFunction</key>
           <txt>CONSTANT_ISSUE</txt>

--- a/src/main/resources/org/sonar/l10n/checkstyle.properties
+++ b/src/main/resources/org/sonar/l10n/checkstyle.properties
@@ -30,7 +30,6 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComple
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck.param.excludeClassesRegexps=User-configured regular expressions to ignore classes
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.metrics.ClassFanOutComplexityCheck.param.excludedPackages=User-configured packages to ignore
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.name=Missing Deprecated
-rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.param.skipNoJavadoc=When this property is set to true check ignore cases when JavaDoc is missing, but still warns when JavaDoc is present but either @deprecated is missing from JavaDoc or @deprecated is missing from the element.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck.name=Outer Type Number
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck.param.max=maximum allowable number of outer types. Default is 1.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck.name=Design For Extension
@@ -99,6 +98,8 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodChec
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.param.allowedAnnotations=List of annotations that could allow missed documentation
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.param.validateThrows=Allows validating throws tags
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.param.logLoadErrors=If set to false a classpath configuration problem is assumed and the TreeWalker stops operating on the class completely. If set to true (the default) , checkstyle assumes a typo or refactoring problem in the javadoc and logs the problem in the normal checkstyle report
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.name=Javadoc Block Tag Location
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.param.tags=Specify the javadoc tags to process.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.name=Javadoc Method
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.param.tokens=definitions to check
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.param.scope=visibility scope where Javadoc comments are checked
@@ -189,6 +190,7 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.param.checkFirstSentence=Whether to check the first sentence for proper end of sentence. Default is true.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.param.endOfSentenceFormat=Format for matching the end of a sentence.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.name=Line Length
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.param.fileExtensions=Specify file extensions that are accepted.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.param.tabWidth=number of expanded spaces for a tab character (''\t'')
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.param.ignorePattern=pattern for lines to ignore
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.param.max=maximum allowable line length. Default is 80.
@@ -501,6 +503,8 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapChec
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck.name=One Top Level Class
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck.name=Overload Methods Declaration Order
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck.name=Unnecessary Semicolon in Enumeration
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck.name=Unnecessary Semicolon After Type Member Declaration
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck.param.tokens=tokens to check
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck.name=Unnecessary Semicolon in Resource Declaration
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck.param.allowWhenNoBraceAfterSemicolon=Allow unnecessary semicolon if closing paren is not on the same line.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck.name=Variable Declaration Usage Distance

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.html
@@ -1,4 +1,17 @@
-Verifies that both the java.lang.Deprecated annotation is present and the @deprecated Javadoc tag is present when either is present.
-
 <p>
+    Verifies that both the @Deprecated annotation is present and the @deprecated javadoc tag are present when either one
+    is present.
+
+    Both ways of flagging deprecation serve their own purpose. The @Deprecated annotation is used for compilers and
+    development tools. The @deprecated javadoc tag is used to document why something is deprecated and what, if any,
+    alternatives exist.
+
+    In order to properly mark something as deprecated both forms of deprecation should be present.
+
+    Package deprecation is a exception to the rule of always using the javadoc tag and annotation to deprecate. It is
+    not clear if the javadoc tool will support it or not as newer versions keep flip flopping on if it is supported or
+    will cause an error. See <a href="https://bugs.openjdk.java.net/browse/JDK-8160601">JDK-8160601</a>. The deprecated
+    javadoc tag is currently the only way to say why the package is deprecated and what to use instead. Until this is
+    resolved, if you don't want to print violations on package-info,
+    you can use a filter to ignore these files until the javadoc tool faithfully supports it.
 </p>

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck.html
@@ -1,0 +1,3 @@
+<p>
+    Checks if unnecessary semicolon is used after type member declaration.
+</p>

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.html
@@ -1,0 +1,5 @@
+<p>
+    Checks that a javadoc block tag appears only at the beginning of a line, ignoring leading asterisks and white space. A block tag is a token that starts with @ symbol and is preceded by a whitespace. This check ignores block tags in comments and inside inline tags {@code } and {@literal }.
+
+    Rationale: according to <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">the specification</a> all javadoc block tags should be placed at the beginning of a line. Tags that are not placed at the beginning are treated as plain text. To recognize intentional tag placement to text area it is better to escape the @ symbol, and all non-escaped tags should be located at the beginning of the line. See NOTE section for details on how to escape.
+</p>

--- a/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -52,9 +52,6 @@
     <priority>MAJOR</priority>
     <name><![CDATA[Missing Deprecated]]></name>
     <configKey><![CDATA[Checker/TreeWalker/MissingDeprecated]]></configKey>
-    <param key="skipNoJavadoc" type="BOOLEAN">
-    </param>
-    <status>READY</status>
   </rule>
 
   <rule key="com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck">
@@ -897,6 +894,16 @@
     <status>READY</status>
   </rule>
 
+  <rule key="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck">
+    <priority>MAJOR</priority>
+    <name><![CDATA[Javadoc Block Tag Location]]></name>
+    <tag>comment</tag>
+    <configKey><![CDATA[Checker/TreeWalker/JavadocBlockTagLocation]]></configKey>
+    <param key="tags" type="s[author,deprecated,exception,hidden,param,provides,return,see,serial,serialData,serialField,since,throws,uses,version]">
+      <defaultValue>author,deprecated,exception,hidden,param,provides,return,see,serial,serialData,serialField,since,throws,uses,version</defaultValue>
+    </param>
+  </rule>
+
   <rule key="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck">
     <priority>MAJOR</priority>
     <name><![CDATA[Javadoc Style]]></name>
@@ -1012,9 +1019,11 @@
     <priority>MAJOR</priority>
     <name><![CDATA[Line Length]]></name>
     <tag>size</tag>
-    <configKey><![CDATA[Checker/TreeWalker/LineLength]]></configKey>
+    <configKey><![CDATA[Checker/LineLength]]></configKey>
     <param key="tabWidth" type="INTEGER">
       <defaultValue>8</defaultValue>
+    </param>
+    <param key="fileExtensions" type="STRING">
     </param>
     <param key="ignorePattern" type="REGULAR_EXPRESSION">
     </param>
@@ -2004,6 +2013,15 @@
     <name><![CDATA[Unnecessary Semicolon in Enumeration]]></name>
     <priority>MAJOR</priority>
     <configKey><![CDATA[Checker/TreeWalker/UnnecessarySemicolonInEnumeration]]></configKey>
+  </rule>
+
+  <rule key="com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck">
+    <name><![CDATA[Unnecessary Semicolon in Enumeration]]></name>
+    <priority>MAJOR</priority>
+    <configKey><![CDATA[Checker/TreeWalker/UnnecessarySemicolonAfterTypeMemberDeclaration]]></configKey>
+    <param key="tokens" type="s[CLASS_DEF,INTERFACE_DEF,ENUM_DEF,ANNOTATION_DEF,VARIABLE_DEF,ANNOTATION_FIELD_DEF,STATIC_INIT,INSTANCE_INIT,CTOR_DEF,METHOD_DEF,ENUM_CONSTANT_DEF]">
+      <defaultValue>CLASS_DEF,INTERFACE_DEF,ENUM_DEF,ANNOTATION_DEF,VARIABLE_DEF,ANNOTATION_FIELD_DEF,STATIC_INIT,INSTANCE_INIT,CTOR_DEF,METHOD_DEF,ENUM_CONSTANT_DEF</defaultValue>
+    </param>
   </rule>
 
   <rule key="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck">

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleProfileExporterTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleProfileExporterTest.java
@@ -102,11 +102,6 @@ public class CheckstyleProfileExporterTest {
                         "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck",
                         "Javadoc").setConfigKey("Checker/JavadocPackage"), RulePriority.MAJOR);
         profile.activateRule(
-                Rule.create("checkstyle",
-                        "com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck",
-                        "Line Length").setConfigKey("Checker/TreeWalker/LineLength"),
-                RulePriority.CRITICAL);
-        profile.activateRule(
                 Rule.create(
                         "checkstyle",
                         "com.puppycrawl.tools.checkstyle.checks.naming.LocalFinalVariableNameCheck",

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -61,7 +61,7 @@ public class CheckstyleRulesDefinitionTest {
         assertThat(repository.language()).isEqualTo("java");
 
         final List<RulesDefinition.Rule> rules = repository.rules();
-        assertThat(rules).hasSize(164);
+        assertThat(rules).hasSize(166);
 
         for (RulesDefinition.Rule rule : rules) {
             assertThat(rule.key()).isNotNull();

--- a/src/test/resources/org/sonar/plugins/checkstyle/CheckstyleProfileExporterTest/singleCheckstyleRulesToExport.xml
+++ b/src/test/resources/org/sonar/plugins/checkstyle/CheckstyleProfileExporterTest/singleCheckstyleRulesToExport.xml
@@ -10,9 +10,6 @@
     <module name="LocalFinalVariableName">
       <property name="severity" value="info"/>
     </module>
-    <module name="LineLength">
-      <property name="severity" value="error"/>
-    </module>
     <module name="SuppressionCommentFilter"/>
   </module>
 </module>


### PR DESCRIPTION
fixes #240 

line length and missing deprecated checks before update:
![linelength_before](https://user-images.githubusercontent.com/653739/66899006-885a6a00-effa-11e9-86cb-28392b16f6cf.PNG)
![missingdeprecated_before](https://user-images.githubusercontent.com/653739/66899014-8bedf100-effa-11e9-8c78-b32ca9e0b867.PNG)

after update they are still working without exception. after recreation of them they work the same:
![linelength_after](https://user-images.githubusercontent.com/653739/66899055-9dcf9400-effa-11e9-8578-7708d557ca8c.PNG)
![missingdepreacted_after](https://user-images.githubusercontent.com/653739/66899057-9dcf9400-effa-11e9-97a9-e43e6d3e0326.PNG)

javadoc block:
![javadocblock](https://user-images.githubusercontent.com/653739/66899078-a6c06580-effa-11e9-80a0-1d8c367c5fb5.PNG)

unnecessary semicolon:
![unnecessarysemicolon](https://user-images.githubusercontent.com/653739/66899092-b17afa80-effa-11e9-80a3-be110d6d5dae.PNG)


however, i was not able to verify the filters:
![unittestignore_before](https://user-images.githubusercontent.com/653739/66899116-bd66bc80-effa-11e9-99f1-449a0bfa3ed7.PNG)
![filters](https://user-images.githubusercontent.com/653739/66899136-c35c9d80-effa-11e9-8029-30929e2dce41.PNG)
can you please check them for the `idFormat` property?