### PR TITLE
Issue #244: update to CS 8.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Compatibility matrix from checkstyle team:
 
 Checkstyle Plugin|Sonar min|Sonar max|Checkstyle|Jdk
 -----------------|---------|---------|----------|---
+4.25|6.7  |7.7+|8.25|1.8
 4.24|6.7  |7.7+|8.24|1.8
 4.23|6.7  |7.7+|8.23|1.8
 4.22|6.7  |7.7+|8.22|1.8

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>8.24</checkstyle.version>
+    <checkstyle.version>8.25</checkstyle.version>
     <sonar.version>6.7</sonar.version>
     <sonar-java.version>5.12.0.17701</sonar-java.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>

--- a/src/main/java/org/sonar/plugins/checkstyle/CheckstyleExecutor.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/CheckstyleExecutor.java
@@ -34,6 +34,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +104,7 @@ public class CheckstyleExecutor {
             if (xmlReport != null) {
                 LOG.info("Checkstyle output report: {}", xmlReport.getAbsolutePath());
                 xmlOutput = FileUtils.openOutputStream(xmlReport);
-                checker.addListener(new XMLLogger(xmlOutput, true));
+                checker.addListener(new XMLLogger(xmlOutput, AutomaticBean.OutputStreamOptions.CLOSE));
             }
 
             checker.setCharset(configuration.getCharset().name());

--- a/src/main/resources/org/sonar/l10n/checkstyle.properties
+++ b/src/main/resources/org/sonar/l10n/checkstyle.properties
@@ -200,6 +200,7 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineChe
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck.param.ignoreCase=Controls whether to ignore case when searching. Default value is false.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck.param.format=illegal pattern. Default value is ^$ (empty).
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck.param.maximum=The maximum number of matches required in each file. Default value is 0.
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck.param.matchAcrossLines=Control whether to match expressions across multiple lines.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck.param.fileExtensions=file type extension of files to process
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.name=Regexp On Filename
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.param.folderPattern=Regular expression to match the folder path against.

--- a/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -156,6 +156,9 @@
     </param>
     <param key="maximum" type="INTEGER">
     </param>
+    <param key="matchAcrossLines" type="BOOLEAN">
+      <defaultValue>false</defaultValue>
+    </param>
     <param key="fileExtensions" type="s{}">
       <defaultValue/>
     </param>


### PR DESCRIPTION
fixes #244 

regexpmultiline check:
![matchacrosslines](https://user-images.githubusercontent.com/653739/67688480-2f93b580-f99a-11e9-9b86-a221c37e44c4.PNG)
results:
![matchacrosslines_results](https://user-images.githubusercontent.com/653739/67688487-33273c80-f99a-11e9-8e58-06f669f7ff77.PNG)
