### PR TITLE
Issue #253: update to CS 8.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Compatibility matrix from checkstyle team:
 
 Checkstyle Plugin|Sonar min|Sonar max|Checkstyle|Jdk
 -----------------|---------|---------|----------|---
+4.27|6.7  |7.7+|8.27|1.8
 4.26|6.7  |7.7+|8.26|1.8
 4.25|6.7  |7.7+|8.25|1.8
 4.24|6.7  |7.7+|8.24|1.8

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>8.26</checkstyle.version>
+    <checkstyle.version>8.27</checkstyle.version>
     <sonar.version>6.7</sonar.version>
     <sonar-java.version>5.12.0.17701</sonar-java.version>
     <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>

--- a/src/main/resources/com/sonar/sqale/checkstyle-model.xml
+++ b/src/main/resources/com/sonar/sqale/checkstyle-model.xml
@@ -1104,6 +1104,19 @@
       </chc>
       <chc>
         <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>30</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
         <rule-key>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</rule-key>
         <prop>
           <key>remediationFunction</key>

--- a/src/main/resources/org/sonar/l10n/checkstyle.properties
+++ b/src/main/resources/org/sonar/l10n/checkstyle.properties
@@ -96,6 +96,8 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodChec
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.param.allowUndeclaredRTE=whether to allow documented exceptions that are not declared if they are a subclass of java.lang.RuntimeException. Default is false.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.param.allowedAnnotations=List of annotations that could allow missed documentation
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.param.validateThrows=Allows validating throws tags
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.name=Javadoc Content Location
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.param.location=Specify the policy on placement of the Javadoc content
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.name=Javadoc Block Tag Location
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.param.tags=Specify the javadoc tags to process.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.name=Javadoc Method

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.html
@@ -1,0 +1,5 @@
+<p>
+    Checks that the Javadoc content begins from the same position
+    for all Javadoc comments in the project. Any leading asterisks and spaces
+    are not counted as the beginning of the content and are therefore ignored.
+</p>

--- a/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -900,6 +900,16 @@
     </param>
   </rule>
 
+  <rule key="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck">
+    <priority>MAJOR</priority>
+    <name><![CDATA[Javadoc Content Location]]></name>
+    <tag>comment</tag>
+    <configKey><![CDATA[Checker/TreeWalker/JavadocContentLocation]]></configKey>
+    <param key="location" type="s[first_line,second_line]">
+      <defaultValue>second_line</defaultValue>
+    </param>
+  </rule>
+
   <rule key="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck">
     <priority>MAJOR</priority>
     <name><![CDATA[Javadoc Style]]></name>

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -61,7 +61,7 @@ public class CheckstyleRulesDefinitionTest {
         assertThat(repository.language()).isEqualTo("java");
 
         final List<RulesDefinition.Rule> rules = repository.rules();
-        assertThat(rules).hasSize(166);
+        assertThat(rules).hasSize(167);
 
         for (RulesDefinition.Rule rule : rules) {
             assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
fix #253 

I have got a problem here as the new check doesn't seem to work.

My example Java class is:
```
/** This comment causes a violation because it starts from the first line
  * and spans several lines.
  */
/**
  * This comment is OK because it starts from the second line.
  */
/** This comment is OK because it is on the single line. */
public class App {
    /** This comment causes a violation because it starts from the first line
      * and spans several lines.
      */
    /**
      * This comment is OK because it starts from the second line.
      */
    /** This comment is OK because it is on the single line. */
    public String getGreeting() {
        return "Hello world.";
    }

    /** This comment causes a violation because it starts from the first line
      * and spans several lines.
      */
    /**
      * This comment is OK because it starts from the second line.
      */
    /** This comment is OK because it is on the single line. */
    public static void main(String[] args) {
        System.out.println(new App().getGreeting());
    }
}
```
which is the example shown here: https://checkstyle.sourceforge.io/config_javadoc.html#JavadocContentLocation_Examples

As for the check in SQ, this is my settings (default values according to https://checkstyle.sourceforge.io/config_javadoc.html#JavadocContentLocation_Properties:
![javadoccontentlocation](https://user-images.githubusercontent.com/653739/70421314-e3906200-1a69-11ea-97e3-2ef4105a27fc.PNG)
