### PR TITLE
#270: send jacoco coverage to sonarqube

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -32,11 +32,12 @@ sonarqube)
   fi
   if [[ -z $SONAR_TOKEN ]]; then echo "SONAR_TOKEN is not set"; sleep 5s; exit 1; fi
   export MAVEN_OPTS='-Xmx2000m'
-  mvn -e -Pno-validations clean package sonar:sonar $SONAR_PR_VARIABLES \
+  mvn -e -Psonarqube-validations clean package jacoco:report sonar:sonar $SONAR_PR_VARIABLES \
        -Dsonar.host.url=https://sonarcloud.io \
        -Dsonar.login=$SONAR_TOKEN \
        -Dsonar.projectKey=checkstyle_sonar-checkstyle \
-       -Dsonar.organization=checkstyle
+       -Dsonar.organization=checkstyle \
+       -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
   echo "report-task.txt:"
   cat target/sonar/report-task.txt
   echo "Verification of sonar gate status"

--- a/pom.xml
+++ b/pom.xml
@@ -784,12 +784,26 @@
       <id>no-validations</id>
       <properties>
         <skipTests>true</skipTests>
+        <skipITs>true</skipITs>
         <checkstyle.skip>true</checkstyle.skip>
         <pmd.skip>true</pmd.skip>
         <spotbugs.skip>true</spotbugs.skip>
         <xml.skip>true</xml.skip>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <jacoco.skip>true</jacoco.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+      </properties>
+    </profile>
+    <profile>
+      <!-- To be used during wercker's sonarqube step. -->
+      <id>sonarqube-validations</id>
+      <properties>
+        <skipITs>true</skipITs>
+        <checkstyle.skip>true</checkstyle.skip>
+        <pmd.skip>true</pmd.skip>
+        <spotbugs.skip>true</spotbugs.skip>
+        <xml.skip>true</xml.skip>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
       </properties>
     </profile>


### PR DESCRIPTION
In order to be able to send JaCoCo reports to Sonarqube, we have to:
- run unit tests instrumented with JaCoCo
- setup Sonar integration correctly