### PR TITLE
Issue #281: update to CS 8.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Compatibility matrix from checkstyle team:
 
 Checkstyle Plugin|Sonar min|Sonar max|Checkstyle|Jdk
 -----------------|---------|---------|----------|---
+4.29|7.9  |7.9+|8.29|1.8
 4.28|7.9  |7.9+|8.28|11
 4.27|6.7  |7.7+|8.27|1.8
 4.26|6.7  |7.7+|8.26|1.8

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>8.28</checkstyle.version>
+    <checkstyle.version>8.29</checkstyle.version>
     <sonar.version>7.9</sonar.version>
     <sonar-java.version>6.0.0.20538</sonar-java.version>
     <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>

--- a/src/it/java/org/checkstyle/plugins/sonar/CheckJarTest.java
+++ b/src/it/java/org/checkstyle/plugins/sonar/CheckJarTest.java
@@ -26,10 +26,15 @@ import java.io.File;
 import org.junit.Test;
 
 public class CheckJarTest {
+    private static final String VERSION = "4.29";
 
     @Test
     public void testJarPresence() {
+        final boolean snapshotExists = new File("target/checkstyle-sonar-plugin-"
+                                                + VERSION + "-SNAPSHOT.jar").exists();
+        final boolean releaseExists = new File("target/checkstyle-sonar-plugin-"
+                                               + VERSION + ".jar").exists();
         assertTrue("Jar should exists",
-                new File("target/checkstyle-sonar-plugin-4.28-SNAPSHOT.jar").exists());
+                   snapshotExists || releaseExists);
     }
 }

--- a/src/main/resources/com/sonar/sqale/checkstyle-model.xml
+++ b/src/main/resources/com/sonar/sqale/checkstyle-model.xml
@@ -1453,6 +1453,19 @@
           <txt>min</txt>
         </prop>
       </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>15</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
     </chc>
   </chc>
   <chc>
@@ -2013,6 +2026,19 @@
       <chc>
         <rule-repo>checkstyle</rule-repo>
         <rule-key>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck</rule-key>
+        <prop>
+          <key>remediationFunction</key>
+          <txt>CONSTANT_ISSUE</txt>
+        </prop>
+        <prop>
+          <key>offset</key>
+          <val>20</val>
+          <txt>min</txt>
+        </prop>
+      </chc>
+      <chc>
+        <rule-repo>checkstyle</rule-repo>
+        <rule-key>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck</rule-key>
         <prop>
           <key>remediationFunction</key>
           <txt>CONSTANT_ISSUE</txt>

--- a/src/main/resources/org/sonar/l10n/checkstyle.properties
+++ b/src/main/resources/org/sonar/l10n/checkstyle.properties
@@ -148,6 +148,7 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.param.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.param.charset=character encoding to use when reading the headerFile
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.param.fileExtensions=file type extension of files to process
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck.name=Avoid Inline Conditionals
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck.name=Avoid No Argument Super Constructor Call
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck.name=Nested Try Depth
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck.param.max=allowed nesting depth. Default is 1.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck.name=No Array Trailing Comma
@@ -450,6 +451,7 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck.pa
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck.name=Array Trailing Comma
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck.name=Generic Whitespace
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck.name=No Clone
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck.name=No Enum Trailing Comma
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck.name=Inner Type Last
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck.name=Outer Type Filename
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck.name=Ordered Properties

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck.html
@@ -1,0 +1,3 @@
+<p>
+    Checks if call to superclass constructor without arguments is present. Such invocation is redundant because constructor body implicitly begins with a superclass constructor invocation super(); See <a href="https://docs.oracle.com/javase/specs/jls/se13/html/jls-8.html#jls-8.8.7">specification</a> for detailed information.
+</p>

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck.html
@@ -1,4 +1,5 @@
-Checks for fall through in switch statements Finds locations where a case contains Java code - but lacks a break, return, throw or continue statement.
-
 <p>
+    Checks for fall through in switch statements Finds locations where a case contains Java code - but lacks a break, return, throw or continue statement.<br>
+
+    The check honors special comments to suppress the warning. By default the texts "fallthru", "fall thru", "fall-thru", "fallthrough", "fall through", "fall-through" "fallsthrough", "falls through", "falls-through" (case sensitive). The comment containing these words must be all on one line, and must be on the last non-empty line before the case triggering the warning or on the same line before the case (ugly, but possible).
 </p>

--- a/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck.html
+++ b/src/main/resources/org/sonar/l10n/checkstyle/rules/checkstyle/com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck.html
@@ -1,0 +1,3 @@
+<p>
+    Checks that enum definition does not contain a trailing comma. Rationale: JLS allows trailing commas in arrays and enumerations, but does not allow them in other locations. To unify the coding style, the use of trailing commas should be prohibited.
+</p>

--- a/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -97,6 +97,12 @@
     <configKey><![CDATA[Checker/TreeWalker/NoClone]]></configKey>
   </rule>
 
+  <rule key="com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck">
+    <priority>MAJOR</priority>
+    <name><![CDATA[No Enum Trailing Comma]]></name>
+    <configKey><![CDATA[Checker/TreeWalker/NoEnumTrailingComma]]></configKey>
+  </rule>
+
   <rule key="com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck">
     <priority>MAJOR</priority>
     <name><![CDATA[No Finalizer]]></name>
@@ -318,6 +324,13 @@
     <priority>MINOR</priority>
     <name><![CDATA[Avoid Inline Conditionals]]></name>
     <configKey><![CDATA[Checker/TreeWalker/AvoidInlineConditionals]]></configKey>
+    <status>READY</status>
+  </rule>
+
+  <rule key="com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck">
+    <priority>MINOR</priority>
+    <name><![CDATA[Avoid No Argument Super Constructor Call]]></name>
+    <configKey><![CDATA[Checker/TreeWalker/AvoidNoArgumentSuperConstructorCall]]></configKey>
     <status>READY</status>
   </rule>
 
@@ -552,8 +565,10 @@
     <name><![CDATA[Fall Through]]></name>
     <configKey><![CDATA[Checker/TreeWalker/FallThrough]]></configKey>
     <param key="checkLastCaseGroup" type="BOOLEAN">
+      <defaultValue>false</defaultValue>
     </param>
     <param key="reliefPattern" type="REGULAR_EXPRESSION">
+      <defaultValue>falls?[ -]?thr(u|ough)</defaultValue>
     </param>
     <status>READY</status>
   </rule>
@@ -1488,7 +1503,7 @@
     <param key="option" type="s[same,alone,alone_or_singleline]">
       <defaultValue>same</defaultValue>
     </param>
-    <param key="tokens" type="s[LITERAL_TRY,LITERAL_CATCH,LITERAL_FINALLY,LITERAL_IF,LITERAL_ELSE,CLASS_DEF,METHOD_DEF,CTOR_DEF,LITERAL_FOR,LITERAL_WHILE,LITERAL_DO,STATIC_INIT,INSTANCE_INIT,ANNOTATION_DEF]">
+    <param key="tokens" type="s[LITERAL_TRY,LITERAL_CATCH,LITERAL_FINALLY,LITERAL_IF,LITERAL_ELSE,CLASS_DEF,METHOD_DEF,CTOR_DEF,LITERAL_FOR,LITERAL_WHILE,LITERAL_DO,STATIC_INIT,INSTANCE_INIT,ANNOTATION_DEF,ENUM_DEF]">
       <defaultValue>LITERAL_TRY,LITERAL_CATCH,LITERAL_FINALLY,LITERAL_IF,LITERAL_ELSE</defaultValue>
     </param>
     <status>READY</status>

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -61,7 +61,7 @@ public class CheckstyleRulesDefinitionTest {
         assertThat(repository.language()).isEqualTo("java");
 
         final List<RulesDefinition.Rule> rules = repository.rules();
-        assertThat(rules).hasSize(168);
+        assertThat(rules).hasSize(170);
 
         for (RulesDefinition.Rule rule : rules) {
             assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
fix #281 

new checks working fine:
![NoEnumTrailingCommaCheck](https://user-images.githubusercontent.com/653739/73429762-b1e69980-433c-11ea-9eea-6f66519a5869.png)
![AvoidNoArgumentSuperConstructorCallCheck](https://user-images.githubusercontent.com/653739/73429763-b27f3000-433c-11ea-92d9-ec6dea5ae780.png)
