### PR TITLE
Issue 322: fix type input validation - caused from 8.36 update onwards

### DIFF
--- a/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
@@ -215,8 +215,29 @@ public class CheckstyleMetadata {
                     valuesArray, valuesArray.length, String[].class)));
         }
         else {
-            param.setType(RuleParamType.STRING);
+            param.setType(getPropertyType(modulePropertyDetails));
         }
+    }
+
+    /**
+     * Get Sonar specific property type from module property type.
+     *
+     * @param modulePropertyDetails module property details
+     * @return sonar property type
+     */
+    private static RuleParamType getPropertyType(ModulePropertyDetails modulePropertyDetails) {
+        final RuleParamType result;
+        switch (modulePropertyDetails.getType()) {
+            case "boolean":
+                result = RuleParamType.BOOLEAN;
+                break;
+            case "int":
+                result = RuleParamType.INTEGER;
+                break;
+            default:
+                result = RuleParamType.STRING;
+        }
+        return result;
     }
 
     /**


### PR DESCRIPTION
#322 

`Boolean`
<img width="1774" alt="Screenshot 2020-08-30 at 9 48 44 PM" src="https://user-images.githubusercontent.com/23253816/91664604-01c55300-eb0e-11ea-877f-18a103e25194.png">

`Integer`
<img width="1792" alt="Screenshot 2020-08-30 at 9 52 39 PM" src="https://user-images.githubusercontent.com/23253816/91664611-07bb3400-eb0e-11ea-9316-ef43c022fe2e.png">

NB: There is no regex type in sonar. 
```
public final class RuleParamType {
    private static final String OPTION_SEPARATOR = ",";
    public static final RuleParamType STRING = new RuleParamType("STRING", new String[0]);
    public static final RuleParamType TEXT = new RuleParamType("TEXT", new String[0]);
    public static final RuleParamType BOOLEAN = new RuleParamType("BOOLEAN", new String[0]);
    public static final RuleParamType INTEGER = new RuleParamType("INTEGER", new String[0]);
    public static final RuleParamType FLOAT = new RuleParamType("FLOAT", new String[0]);
    private static final String CSV_SPLIT_REGEX = ",(?=([^\"]*\"[^\"]*\")*[^\"]*$)";
```