### PR TITLE
Issue #328: Allow lower case enum values in check config

### DIFF
--- a/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -170,6 +171,7 @@ public class CheckstyleMetadata {
         final List<String> enumVals = new ArrayList<>();
         for (Object val : vals) {
             enumVals.add(val.toString());
+            enumVals.add(val.toString().toLowerCase(Locale.ENGLISH));
         }
         return enumVals;
     }


### PR DESCRIPTION
#328
`lowerCase`
<img width="1018" alt="Screenshot 2020-09-03 at 9 15 35 PM" src="https://user-images.githubusercontent.com/23253816/92138361-e6b75380-ee2b-11ea-9f10-d6d5e96ae040.png">

`upperCase`
<img width="1018" alt="Screenshot 2020-09-03 at 9 15 55 PM" src="https://user-images.githubusercontent.com/23253816/92138367-e8811700-ee2b-11ea-93e4-b6d744a4e33a.png">

`accetable values list`
<img width="737" alt="Screenshot 2020-09-03 at 9 18 21 PM" src="https://user-images.githubusercontent.com/23253816/92138379-ecad3480-ee2b-11ea-824a-f299c132a12e.png">
