### PR TITLE
Issue #353: update to CS 8.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Compatibility matrix from checkstyle team:
 
 Checkstyle Plugin|Sonar min|Sonar max|Checkstyle|Jdk
 -----------------|---------|---------|----------|---
+8.40|7.9  |7.9+|8.40|1.8
 8.39|7.9  |7.9+|8.39|1.8
 8.38|7.9  |7.9+|8.38|1.8
 8.37|7.9  |7.9+|8.37|1.8

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>8.39</checkstyle.version>
+    <checkstyle.version>8.40</checkstyle.version>
     <sonar.version>7.9</sonar.version>
     <sonar-java.version>6.0.0.20538</sonar-java.version>
     <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>

--- a/src/main/resources/org/sonar/l10n/checkstyle.properties
+++ b/src/main/resources/org/sonar/l10n/checkstyle.properties
@@ -34,6 +34,7 @@ rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberChec
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck.param.max=maximum allowable number of outer types. Default is 1.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck.name=Design For Extension
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck.param.ignoredAnnotations=Annotations which allow the check to skip the method from validation.
+rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck.param.requiredJavadocPhrase=Specify the comment text pattern which qualifies a method as designed for extension. Supports multi-line regex.
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck.name=Illegal Throws
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck.param.illegalClassNames=throw class names to reject
 rule.checkstyle.com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck.param.ignoredMethodNames=names of methods to ignore. Default is "finalize".

--- a/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
+++ b/src/main/resources/org/sonar/plugins/checkstyle/rules.xml
@@ -493,6 +493,9 @@
     <param key="ignoredAnnotations" type="s{}">
       <defaultValue>Test,Before,After,BeforeClass,AfterClass</defaultValue>
     </param>
+    <param key="requiredJavadocPhrase" type="REGULAR_EXPRESSION">
+      <defaultValue>.*</defaultValue>
+    </param>
   </rule>
 
   <rule key="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck">

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -80,7 +80,7 @@ public class CheckstyleRulesDefinitionTest {
         // such number should not change during checkstyle version upgrade
         assertThat(duplicatedRuleWithTemplate).hasSize(174);
         // all new Rules should fall in this group
-        assertThat(rulesWithDuplicateTemplate).hasSize(8);
+        assertThat(rulesWithDuplicateTemplate).hasSize(9);
 
         for (RulesDefinition.Rule rule : rules) {
             assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
fix #353.

New check:
<img width="1920" alt="Screenshot 2021-02-16 at 7 57 21 PM" src="https://user-images.githubusercontent.com/653739/108108814-66ab4000-7091-11eb-8b83-e927abb89137.png">

DesignForExtension new property (default value):
<img width="1912" alt="Screenshot 2021-02-16 at 7 57 31 PM" src="https://user-images.githubusercontent.com/653739/108108834-6e6ae480-7091-11eb-8579-7888ac4ba4d7.png">
