### PR TITLE
infra: restore Travis and activate partner queue arch to not use Travis credits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,36 @@
-# travis is disabled, all jobs moved to GitHub actions
-#language: java
-#sudo: false
-#install: true
-#
-#script:
-#  - |
-#    set -e
-#    eval $CMD;
-#
-#cache:
-#  apt: true
-#  directories:
-#    - ~/.m2
-#
-#addons:
-#  apt:
-#    packages:
-#      - xsltproc
-#      - xmlstarlet
-#
-#branches:
-#  only:
-#    - master
-#
-#matrix:
-#  fast_finish: true
-#  include:
-#    - jdk: openjdk11
-#      env: CMD="./.ci/ci.sh install"
-#
-#    - jdk: openjdk8
-#      env: CMD="./.ci/ci.sh install"
-#
-#    - jdk: openjdk11
-#      env: CMD="./.ci/ci.sh integration-tests"
-#
-#    - jdk: openjdk11
-#      env: CMD="./.ci/ci.sh nondex"
+version: ~> 1.0
+dist: focal
+# this arch is required as is for Partner Queue Solution - DO NOT MODIFY
+arch: ppc64le
+
+language: java
+sudo: false
+
+cache:
+ apt: true
+ directories:
+   - ~/.m2
+
+addons:
+ apt:
+   packages:
+     - xsltproc
+     - xmlstarlet
+
+branches:
+ only:
+   - master
+
+install:
+  -
+
+matrix:
+ fast_finish: true
+ include:
+   - jdk: openjdk11
+     env: CMD="./.ci/ci.sh install"
+
+script:
+ - |
+   set -e
+   eval $CMD;


### PR DESCRIPTION
https://docs.travis-ci.com/user/multi-cpu-architectures/

> Partner Queue Solution #
With the introduction of a new billing system in Travis CI, the IBM and part of the ARM64 infrastructures are kept available free of charge for OSS as a part of the Partner Queue Solution. For more details see Billing Overview - Usage based Plans - Credits.

We will duplicate CI job execution in Travis for now, later on we can let Travis do something unique.