### PR TITLE
Issue #403: upgrade to checkstyle 10.0; drop java 1.8 support

### DIFF
--- a/.github/workflows/sonar-checkstyle-workflows.yml
+++ b/.github/workflows/sonar-checkstyle-workflows.yml
@@ -7,17 +7,6 @@ on:
   pull_request:
 
 jobs:
-  mvn-install-java-8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: install
-        run: "./.ci/ci.sh install"
-
   mvn-install-java-11:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ target/
 .project
 .settings
 
+# ---- VSCode
+.vscode/
+
 # ---- Mac OS X
 .DS_Store?
 Icon?

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Compatibility matrix from checkstyle team:
 
 | Checkstyle Plugin | Sonar min | Sonar max | Checkstyle | Jdk |
 |-------------------|-----------|-----------|------------|-----|
+| 10.0              | 8.9       | 8.9+      | 10.0       | 11  |
 | 9.3               | 8.9       | 8.9+      | 9.3        | 1.8 |
 | 9.2.1             | 8.9       | 8.9+      | 9.2.1      | 1.8 |
 | 9.2               | 8.9       | 8.9+      | 9.2        | 1.8 |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.checkstyle</groupId>
   <artifactId>checkstyle-sonar-plugin</artifactId>
-  <version>9.4-SNAPSHOT</version>
+  <version>10.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>Checkstyle SonarQube Plugin</name>
@@ -93,7 +93,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>9.3</checkstyle.version>
+    <checkstyle.version>10.0</checkstyle.version>
     <sonar.version>8.9.0.43852</sonar.version>
     <sonar-java.version>7.2.0.26923</sonar-java.version>
     <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
@@ -103,7 +103,7 @@
       8.35
     </maven.sevntu.checkstyle.plugin.checkstyle.version>
     <maven.jacoco.plugin.version>0.8.5</maven.jacoco.plugin.version>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- we disable ITs by default as it need download of 200MB sonar application jar -->
     <skipITs>true</skipITs>

--- a/src/it/java/org/checkstyle/plugins/sonar/RunPluginTest.java
+++ b/src/it/java/org/checkstyle/plugins/sonar/RunPluginTest.java
@@ -154,8 +154,8 @@ public class RunPluginTest {
 
     private static void assertNoDifferences() {
         try {
-            final String differences = new String(Files
-                    .readAllBytes(new File(litsDifferencesPath()).toPath()), UTF_8);
+            final String differences = Files
+                    .readString(new File(litsDifferencesPath()).toPath(), UTF_8);
 
             Assertions.assertThat(differences)
                     .isEmpty();

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleConstantsTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleConstantsTest.java
@@ -23,6 +23,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.lang.reflect.Constructor;
 
+import org.eclipse.jdt.core.dom.Modifier;
 import org.junit.Test;
 
 public class CheckstyleConstantsTest {
@@ -31,7 +32,7 @@ public class CheckstyleConstantsTest {
     public void privateConstructor() throws ReflectiveOperationException {
         final Constructor<CheckstyleConstants> constructor = CheckstyleConstants.class
                 .getDeclaredConstructor();
-        assertThat(constructor.isAccessible()).isFalse();
+        assertThat(Modifier.isPrivate(constructor.getModifiers())).isTrue();
         constructor.setAccessible(true);
         constructor.newInstance();
     }

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleSeverityUtilsTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleSeverityUtilsTest.java
@@ -23,6 +23,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.lang.reflect.Constructor;
 
+import org.eclipse.jdt.core.dom.Modifier;
 import org.junit.Assert;
 import org.junit.Test;
 import org.sonar.api.rules.RulePriority;
@@ -72,7 +73,7 @@ public class CheckstyleSeverityUtilsTest {
         final Constructor<CheckstyleSeverityUtils> constructor = CheckstyleSeverityUtils.class
                 .getDeclaredConstructor();
 
-        assertThat(constructor.isAccessible()).isFalse();
+        assertThat(Modifier.isPrivate(constructor.getModifiers())).isTrue();
         constructor.setAccessible(true);
         constructor.newInstance();
     }


### PR DESCRIPTION
- fixes #403
- drops java 1.8 support in accordance with checkstyle 10.0

Whitespace After check:
<img width="830" alt="Screenshot 2022-03-04 at 2 21 17 PM" src="https://user-images.githubusercontent.com/653739/156771110-94eeda98-24b2-412c-b4bd-05aadaa2d661.png">

