### PR TITLE
Issue #40: removed sonar-java-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,19 +111,11 @@
   </properties>
 
   <dependencies>
-    <!-- till https://github.com/checkstyle/sonar-checkstyle/issues/40 -->
     <dependency>
-      <groupId>org.sonarsource.java</groupId>
-      <artifactId>sonar-java-plugin</artifactId>
-      <version>${sonar-java.version}</version>
+      <groupId>com.fasterxml.staxmate</groupId>
+      <artifactId>staxmate</artifactId>
+      <version>2.4.0</version>
       <scope>provided</scope>
-      <!-- to avoid 4.5.1 api pickup -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.sonar</groupId>
-          <artifactId>sonar-plugin-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <!-- required to load external descriptiona, see CheckstyleRulesDefinition -->
     <dependency>

--- a/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
@@ -22,7 +22,6 @@ package org.sonar.plugins.checkstyle;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
-import org.sonar.plugins.java.Java;
 
 public class CheckstyleSensor implements Sensor {
 
@@ -34,7 +33,7 @@ public class CheckstyleSensor implements Sensor {
 
     @Override
     public void describe(SensorDescriptor descriptor) {
-        descriptor.onlyOnLanguage(Java.KEY).name("CheckstyleSensor");
+        descriptor.onlyOnLanguage("java").name("CheckstyleSensor");
     }
 
     @Override

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleSensorTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleSensorTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import org.junit.Test;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
-import org.sonar.plugins.java.Java;
 
 public class CheckstyleSensorTest {
 
@@ -37,7 +36,7 @@ public class CheckstyleSensorTest {
         final CheckstyleSensor sensor = new CheckstyleSensor(null);
 
         sensor.describe(descriptor);
-        assertThat(descriptor.languages()).containsOnly(Java.KEY);
+        assertThat(descriptor.languages()).containsOnly("java");
         assertThat(descriptor.name()).isNotEmpty();
     }
 


### PR DESCRIPTION
Issue #40

Removed the dependency.

I was not seeing any classpath shenanigans mentioned in the issue unless its happening via reflection or such.


The code before this was causing issues with Eclipse:
> The package javax.xml.stream is accessible from more than one module: <unnamed>, java.xml	CheckstyleProfileImporter.java	/sonar-checkstyle/src/main/java/org/sonar/plugins/checkstyle	line 28	Java Problem

https://stackoverflow.com/questions/55571046/eclipse-is-confused-by-imports-accessible-from-more-than-one-module