### PR TITLE
dependency: upgrade jackson.dataformat to 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,12 +297,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.12.6</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.1</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrades jackson.dataformat to avoid some vulnerabilites in org.yaml:snakeyaml . This upgrades snakeyaml to 1.33 (from 1.27). 1.31 and 1.32 is the reported vulnerable versions.

This dependency is used in [CheckstyleMetadata](https://github.com/checkstyle/sonar-checkstyle/blob/f7f93d4db2d2c905daf2f05280a92a7248a71429/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java#L49) .

https://app.snyk.io/org/checkstyle/project/c790296d-5e05-4755-b64c-85724020c357?utm_campaign=vuln_alert&utm_medium=email&utm_source=Project&fromGitHubAuth=true