### PR TITLE
minor: splits up javadoc suppressions

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -6,7 +6,9 @@
 
 <suppressions>
     <!-- START of legacy code, all violations will be resolved eventually -->
-    <suppress checks="Javadoc*" files=".*[\\/]src[\\/]main[\\/]"/>
+    <suppress checks="Javadoc*" files=".*[\\/]src[\\/]main[\\/]" message="Summary javadoc is missing"/>
+    <suppress checks="Javadoc*" files=".*[\\/]src[\\/]main[\\/]" message="Missing a Javadoc comment"/>
+    <suppress checks="Javadoc*" files=".*[\\/]src[\\/]main[\\/]" message="Missing package-info.java file"/>
     <suppress checks="DesignForExtension" files=".*[\\/]src[\\/]main[\\/]"/>
     <suppress checks="WriteTag" files=".*[\\/]src[\\/]main[\\/]"/>
     <suppress checks="IllegalCatch" files=".*[\\/]src[\\/]main[\\/]"/>

--- a/src/main/java/org/sonar/plugins/checkstyle/CheckstyleExecutor.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/CheckstyleExecutor.java
@@ -64,6 +64,7 @@ public class CheckstyleExecutor {
     /**
      * Execute Checkstyle and return the generated XML report.
      *
+     * @param context The context of the execution.
      * @noinspection TooBroadScope
      * @noinspectionreason Cache the value of the default locale.
      */

--- a/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
@@ -152,6 +152,7 @@ public class CheckstyleMetadata {
      *
      * @param checkName check name
      * @return check class
+     * @throws IllegalStateException if the class cannot be found.
      */
     private Class<?> getClass(String checkName) {
         final ClassLoader loader = getClass().getClassLoader();
@@ -233,7 +234,7 @@ public class CheckstyleMetadata {
 
     /**
      * This check is required since the PARAM_TYPE column has size 512, and exceeding it
-     * will result in an error in DB updates
+     * will result in an error in DB updates.
      *
      * @param values array of values
      * @return true if the size has exceeded the limit
@@ -308,6 +309,7 @@ public class CheckstyleMetadata {
      *
      * @param fileName YML config file
      * @return map of additional metadata
+     * @throws IllegalStateException if there is an issue loading the file.
      */
     private static Map<String, SonarRulePropertyLoader.AdditionalRuleProperties>
         getAdditionalDetails(String fileName) {

--- a/src/main/java/org/sonar/plugins/checkstyle/rule/ActiveRuleWrapper.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/rule/ActiveRuleWrapper.java
@@ -26,9 +26,11 @@ import java.util.Map;
  * on the {@link org.sonar.api.batch.ScannerSide} for generating CheckStyle configurations,
  * we must make it compatible for the new {@link org.sonar.api.batch.rule.ActiveRules}.
  *
+ * <p>
  * Hence, to gain compatibility with server and scanner side in the exporter,
  * we have to wrap either {@link org.sonar.api.batch.rule.ActiveRule} or
  * {@link org.sonar.api.rules.ActiveRule} for usage in the exporter.
+ * </p>
  */
 public interface ActiveRuleWrapper {
     String getInternalKey();


### PR DESCRIPTION
Makes the list more manageable.