### PR TITLE
Issue #455: upgrade to checkstyle 10.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Compatibility matrix from checkstyle team:
 
 | Checkstyle Plugin | Sonar min | Sonar max | Checkstyle | Jdk |
 |-------------------|-----------|-----------|------------|-----|
+| 10.6              | 9.0       | 9.0+      | 10.6.0     | 11  |
 | 10.5              | 9.0       | 9.0+      | 10.5       | 11  |
 | 10.4              | 9.0       | 9.0+      | 10.4       | 11  |
 | 10.3.4            | 9.0       | 9.0+      | 10.3.4     | 11  |

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>10.5.0</checkstyle.version>
+    <checkstyle.version>10.6.0</checkstyle.version>
     <sonar.version>8.9.0.43852</sonar.version>
     <sonar-java.version>7.2.0.26923</sonar-java.version>
     <maven.sevntu.checkstyle.plugin.version>1.44.1</maven.sevntu.checkstyle.plugin.version>
@@ -102,8 +102,8 @@
       10.4
     </maven.sevntu.checkstyle.plugin.checkstyle.version>
     <antrun.plugin.version>3.1.0</antrun.plugin.version>
-    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${maven.sevntu.checkstyle.plugin.checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
-    <checkstyle.sevntu.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_sevntu_checks.xml</checkstyle.sevntu.configLocation>
+    <checkstyle.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${checkstyle.version}/config/checkstyle_checks.xml</checkstyle.configLocation>
+    <checkstyle.sevntu.configLocation>https://raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${maven.sevntu.checkstyle.plugin.checkstyle.version}/config/checkstyle_sevntu_checks.xml</checkstyle.sevntu.configLocation>
     <maven.jacoco.plugin.version>0.8.5</maven.jacoco.plugin.version>
     <java.version>11</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
fixes #455 

N.B.: sevntu and checkstyle config locations have been mixed up; corrected both lines

javadoc style check:
<img width="826" alt="Screenshot 2023-02-11 at 5 19 14 PM" src="https://user-images.githubusercontent.com/653739/218269016-2ac3d899-ecc8-47f3-891e-e932ea59e911.png">
