### PR TITLE
Issue #467: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/bump-license-year.yml
+++ b/.github/workflows/bump-license-year.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set Current Year
         id: CURRENT_YEAR
         run: |
-          echo "::set-output name=year::$(date +'%Y')"
+          echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
       - name: Modify Files
         run: |
           ./.ci/bump-license-year.sh $(expr ${{ env.YEAR }} - 1) ${{ env.YEAR }} .


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve  #467 

Update `bump-license-year.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo "::set-output name=year::$(date +'%Y')"
```

**TO-BE**

```yml
run: |
  echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
```
