### PR TITLE
[WIP] minor: make private class final with default constructor

### DIFF
--- a/src/main/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporter.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporter.java
@@ -210,7 +210,7 @@ public class CheckstyleProfileImporter extends ProfileImporter {
         }
     }
 
-    private static class Module {
+    private static final class Module {
         private final Map<String, String> properties = new HashMap<>();
         private final List<Module> modules = new ArrayList<>();
         private String name;

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleProfileExporterTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleProfileExporterTest.java
@@ -267,7 +267,7 @@ public class CheckstyleProfileExporterTest {
         return StringUtils.remove(xml, CheckstyleProfileExporter.DOCTYPE_DECLARATION);
     }
 
-    private static class IoExceptionWriter extends Writer {
+    private static final class IoExceptionWriter extends Writer {
 
         @Override
         public void write(char[] cbuf, int off, int len) throws IOException {
@@ -295,7 +295,7 @@ public class CheckstyleProfileExporterTest {
      * Once we increase compatibility to 7.X LTS,
      * we can remove this class and use the builder pattern directly.
      */
-    private static class TestActiveRule implements ActiveRule {
+    private static final class TestActiveRule implements ActiveRule {
 
         @Override
         public RuleKey ruleKey() {

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporterTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleProfileImporterTest.java
@@ -181,7 +181,7 @@ public class CheckstyleProfileImporterTest {
         return ruleFinder;
     }
 
-    private static class RuleAnswer implements Answer<Rule> {
+    private static final class RuleAnswer implements Answer<Rule> {
         @Override
         public Rule answer(InvocationOnMock iom) {
             final RuleQuery query = (RuleQuery) iom.getArguments()[0];


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class. 
and  according to the check https://checkstyle.org/config_design.html#FinalClass  a class that has only private constructors and has no descendant classes is declared as final.