### PR TITLE
minor: Remove project transfer note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 Sonar Checkstyle
 ==========
 
-An Official announcement of project transfer - https://groups.google.com/d/topic/sonarqube/HXXxOWS_sOs/discussion
-
 ## Description / Features
 
 This plugin provides coding rules from [Checkstyle](http://checkstyle.sourceforge.net/).


### PR DESCRIPTION
This refers to an event 8 years in the past and is more confusing than helpful.