### PR TITLE
config: use sonar.token instead of sonar.login in ci

### DIFF
--- a/.ci/sonarqube.sh
+++ b/.ci/sonarqube.sh
@@ -22,7 +22,7 @@ export MAVEN_OPTS='-Xmx2000m'
 mvn -e --no-transfer-progress -Pno-validations clean package sonar:sonar \
  $SONAR_PR_VARIABLES \
  -Dsonar.host.url=https://sonarcloud.io \
- -Dsonar.login="$SONAR_TOKEN" \
+ -Dsonar.token="$SONAR_TOKEN" \
  -Dsonar.projectKey=checkstyle_sonar-checkstyle \
  -Dsonar.organization=checkstyle
 

--- a/.ci/sonarqube.sh
+++ b/.ci/sonarqube.sh
@@ -30,5 +30,5 @@ echo "report-task.txt:"
 cat target/sonar/report-task.txt
 
 echo "Verification of sonar gate status"
-export SONAR_API_TOKEN=$SONAR_TOKEN
+export SONAR_TOKEN=$SONAR_TOKEN
 ./.ci/sonar-break-build.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: |
             export PR_NUMBER=$CIRCLE_PR_NUMBER
             export PR_BRANCH_NAME=$CIRCLE_BRANCH
-            export SONAR_API_TOKEN=$SONAR_TOKEN
+            export SONAR_TOKEN=$SONAR_TOKEN
             ./.ci/sonarqube.sh
 
 workflows:


### PR DESCRIPTION
The goal of this PR is to fix the SonarCloud CI run. Since this is my first PR here, I could not verify that this fixes it properly, but at least it should remove the depreaction warning in SonarCloud.

In SonarQube and SonarCloud the `sonar.login` property got deprecated and `sonar.token` got introduced instead from SonarQube 10.0 (see the [the ticket about this in SonarQube's Jira](https://sonarsource.atlassian.net/browse/SONAR-18591)).
The same token can be reused from earlier (see using token in [9.9 docs](https://docs.sonarsource.com/sonarqube-server/9.9/user-guide/user-account/generating-and-using-tokens#using-a-token) and [10.0 docs](http://docs.sonarsource.com/sonarqube-server/10.0/user-guide/user-account/generating-and-using-tokens#using-a-token)).

Last week when I posted [this](https://github.com/checkstyle/sonar-checkstyle/pull/560#issuecomment-4170705738) comment, I could still see the results on SonarCloud for the [last successful run on master](https://github.com/checkstyle/sonar-checkstyle/runs/40027799815). At that time on SonarCloud's page there was a warning about deprecation of the `sonar.login` property.
However the last successful run is a bit more than a year old, so it might be that SonarSource made some cleanup, this might be the reason why the analysis details page gives `Component key 'checkstyle_sonar-checkstyle' not found` error now.

However the project uses `sonar.login` not only in the `.ci/sonarqube.sh` file, which I modified (see [search](https://github.com/search?q=repo%3Acheckstyle%2Fsonar-checkstyle%20sonar.login&type=code)), but in those cases SonarQube's 9.9 or earlier versions are used, which don't contain the sonar.token property yet. So only modifying the token would cause further issues.

I could not found a related issue, and from the listed options `(config)` prefix seemed to be most suitable. Please LMK if I should modify it.