### PR TITLE
fix: use switch pattern matching

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -25,8 +25,4 @@
     <suppress checks="AnonInnerLength" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="ClassDataAbstractionCoupling" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="TrailingComment" files=".*[\\/]Checkstyle(RulesDefinition|Metadata)\.java"/>
-
-    <!-- Suppress these checks until the plugin is upgraded to 13.4.1 and works with the dependency and Java upgrades. -->
-    <suppress checks="UseEnhancedSwitch" files=".*[\\/]src[\\/]main[\\/]"/>
-    <suppress checks="MissingNullCaseInSwitch" files=".*[\\/]src[\\/]main[\\/]"/>
 </suppressions>

--- a/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSeverityUtils.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSeverityUtils.java
@@ -28,24 +28,12 @@ public final class CheckstyleSeverityUtils {
     }
 
     public static String toSeverity(String priority) {
-        final String result;
-
-        switch (priority) {
-            case "BLOCKER":
-            case "CRITICAL":
-                result = SeverityLevel.ERROR.getName();
-                break;
-            case "MAJOR":
-                result = SeverityLevel.WARNING.getName();
-                break;
-            case "MINOR":
-            case "INFO":
-                result = SeverityLevel.INFO.getName();
-                break;
-            default:
+        return switch (priority) {
+            case "BLOCKER", "CRITICAL" -> SeverityLevel.ERROR.getName();
+            case "MAJOR" -> SeverityLevel.WARNING.getName();
+            case "MINOR", "INFO" -> SeverityLevel.INFO.getName();
+            case null, default ->
                 throw new IllegalArgumentException("Priority not supported: " + priority);
-        }
-
-        return result;
+        };
     }
 }

--- a/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/metadata/CheckstyleMetadata.java
@@ -257,23 +257,12 @@ public class CheckstyleMetadata {
      * @return sonar property type
      */
     private static RuleParamType getPropertyType(ModulePropertyDetails modulePropertyDetails) {
-        final RuleParamType result;
-        switch (modulePropertyDetails.getType()) {
-            case "boolean":
-                result = RuleParamType.BOOLEAN;
-                break;
-            case "int":
-            case "long":
-                result = RuleParamType.INTEGER;
-                break;
-            case "float":
-            case "double":
-                result = RuleParamType.FLOAT;
-                break;
-            default:
-                result = RuleParamType.STRING;
-        }
-        return result;
+        return switch (modulePropertyDetails.getType()) {
+            case "boolean" -> RuleParamType.BOOLEAN;
+            case "int", "long" -> RuleParamType.INTEGER;
+            case "float", "double" -> RuleParamType.FLOAT;
+            case null, default -> RuleParamType.STRING;
+        };
     }
 
     /**


### PR DESCRIPTION
Plugin code is adjusted to use pattern matching and null handling for switch statements.
With these changes **Checkstyle** switch checks should not be suppressed.