### PR TITLE
feat: add config option to disable the sensor

### DIFF
--- a/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
+++ b/src/main/java/org/sonar/plugins/checkstyle/CheckstyleSensor.java
@@ -19,13 +19,17 @@
 
 package org.sonar.plugins.checkstyle;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.scanner.sensor.ProjectSensor;
 
 public class CheckstyleSensor implements ProjectSensor {
+    private static final String CHECKSTYLE_ENABLED = "sonar.checkstyle.enabled";
 
     private final CheckstyleExecutor executor;
+    private static final Logger LOG = LoggerFactory.getLogger(CheckstyleSensor.class);
 
     public CheckstyleSensor(CheckstyleExecutor executor) {
         this.executor = executor;
@@ -38,7 +42,11 @@ public class CheckstyleSensor implements ProjectSensor {
 
     @Override
     public void execute(SensorContext context) {
-        executor.execute(context);
+        if (context.config().getBoolean(CHECKSTYLE_ENABLED).orElse(true)) {
+            executor.execute(context);
+        } else {
+            LOG.info("Checkstyle plugin is disabled.");
+        }
     }
 
     @Override

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleSensorTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleSensorTest.java
@@ -23,12 +23,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
+import org.sonar.api.config.Configuration;
 
 class CheckstyleSensorTest {
+    private static final String CHECKSTYLE_ENABLED = "sonar.checkstyle.enabled";
 
     @Test
     void shouldDescribePluginCorrectly() {
@@ -43,9 +48,14 @@ class CheckstyleSensorTest {
     @Test
     void shouldExecuteExecutorWithContext() {
         final SensorContext context = mock(SensorContext.class);
+        final Configuration configuration = mock(Configuration.class);
         final CheckstyleExecutor executor = mock(CheckstyleExecutor.class);
 
         final CheckstyleSensor sensor = new CheckstyleSensor(executor);
+
+        when(context.config()).thenReturn(configuration);
+        when(configuration.getBoolean(CHECKSTYLE_ENABLED)).thenReturn(Optional.of(true));
+
         sensor.execute(context);
 
         verify(executor, times(1)).execute(context);


### PR DESCRIPTION

This PR adds a config option `sonar.checkstyle.enabled`.

While using the plugin there were some cases when **checkstyle** was unable to parse tricky Java code. This resulted in the whole analysis failing.

The above option makes it possible to completely disable the checkstyle sensor for a certain project while the plugin is still available globally.

The config option defaults to **true** so there will be no need for any config modifications for existing users.