### PR TITLE
feat: update checkstyle to 13.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.checkstyle</groupId>
   <artifactId>checkstyle-sonar-plugin</artifactId>
-  <version>13.4.2-SNAPSHOT</version>
+  <version>13.7.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
 
   <name>Checkstyle SonarQube Plugin</name>
@@ -93,9 +93,9 @@
   </ciManagement>
 
   <properties>
-    <checkstyle.version>13.4.2</checkstyle.version>
+    <checkstyle.version>13.7.0</checkstyle.version>
     <sonar.version>25.2.0.102705</sonar.version>
-    <sonar.api-version>11.3.0.2824</sonar.api-version>
+    <sonar.api-version>11.1.0.2693</sonar.api-version>
     <maven.sevntu.checkstyle.plugin.version>1.44.1</maven.sevntu.checkstyle.plugin.version>
     <!-- it should be a version of checkstyle that is compatible/compiled with sevntu -->
     <maven.sevntu.checkstyle.plugin.checkstyle.version>

--- a/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
+++ b/src/test/java/org/sonar/plugins/checkstyle/CheckstyleRulesDefinitionTest.java
@@ -75,7 +75,7 @@ class CheckstyleRulesDefinitionTest {
         // such number should not change during checkstyle version upgrade
         assertThat(duplicatedRuleWithTemplate).hasSize(0);
         // all new Rules should fall in this group
-        assertThat(rulesWithDuplicateTemplate).hasSize(203);
+        assertThat(rulesWithDuplicateTemplate).hasSize(204);
 
         for (RulesDefinition.Rule rule : rules) {
             assertThat(rule.key()).isNotNull();


### PR DESCRIPTION
This PR updates checkstyle to 13.7.0.

Sonar api version is rolled back to 11.1.0.2693 as that is the correct version for Sonarqube community 25.2 (11.3.0.2824 is for version 25.4). As 25.2 is the minimal version that supports java 21, I believe we should keep sonar api version as low as possible.

The change is tested on Sonarqube Community 25.2 and current latest release 26.6.

Related to #604 
