### PR TITLE
minor(ci): change community version to 25.2 for plugin testing

### DIFF
--- a/.github/workflows/sonar-checkstyle-workflows.yml
+++ b/.github/workflows/sonar-checkstyle-workflows.yml
@@ -88,7 +88,7 @@ jobs:
       max-parallel: 4
       matrix:
         java-version: ['21']
-        sq-version: ['latest', '26.1.0.118079-community']
+        sq-version: ['latest', '25.2.0.102705-community']
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This PR changes Sonarqube Community version to 25.2 
That is the oldest community release supporting java 21 (that is required by checkstyle). Thus, this is a good baseline for plugin testing.

resolves #610 
